### PR TITLE
Edited ExecuteSQL function

### DIFF
--- a/class.MySQL.php
+++ b/class.MySQL.php
@@ -121,12 +121,7 @@ class MySQL {
 			$this->records 	= @mysql_num_rows($this->result);
 			$this->affected	= @mysql_affected_rows($this->databaseLink);
 			
-			if($this->records > 0){
-				$this->ArrayResults();
-				return $this->arrayedResult;
-			}else{
-				return true;
-			}
+			return true;
 			
 		}else{
 			$this->lastError = mysql_error($this->databaseLink);


### PR DESCRIPTION
Fixes ArrayResults function when using Select method, returned empty array before
