### PR TITLE
removed table prefix call which was missing.

### DIFF
--- a/class.DBPDO.php
+++ b/class.DBPDO.php
@@ -40,7 +40,7 @@ class DBPDO {
 
 	function table_exists($table_name){
 		$stmt = $this->prep_query('SHOW TABLES LIKE ?');
-		$stmt->execute(array($this->add_table_prefix($table_name)));
+		$stmt->execute(array($table_name));
 		return $stmt->rowCount() > 0;
 	}
 


### PR DESCRIPTION
There was no function named add_table_prefix so the table_exists function was throwing an error.